### PR TITLE
Cleaned up summed.py

### DIFF
--- a/summed.py
+++ b/summed.py
@@ -9,8 +9,8 @@ def read_files(files: Generator[str, None, None]) -> str:
         # Skip output file
         if f != OUTPUT_FILE:
             for line in open(f, 'r'):
-                # Skip comments
-                if line[0] != '#':
+                # Skip comments and empty lines
+                if line[0] not in ['#', '\n']:
                     yield line
 
 

--- a/summed.py
+++ b/summed.py
@@ -1,26 +1,44 @@
-# Set cwd to file location
-os.chdir(os.path.dirname(os.path.realpath(__file__)))
+import glob
+from typing import Generator
 
-# Get every .txt file in folder (except output file)
-txt_files = [f for f in glob.glob("*.txt")]
-txt_files.remove("everything.txt")
+OUTPUT_FILE = 'everything.txt'
 
-# For non-duplicates lines + count + write
-read_lines = set()
 
-# Info text to go on top, formattable at "Total number of network filters"
-info_text = "\n#------------------------------------[UPDATE]--------------------------------------\n# Title: The Block List Project\n# Expires: 1 day\n# Homepage: https://blocklist.site\n# Help: https://github.com/blocklistproject/lists/wiki/\n# License: https://unlicense.org\n# Total number of network filters: {}\n#------------------------------------[SUPPORT]-------------------------------------\n# You can support by:\n# - reporting false positives\n# - making a donation: https://paypal.me/blocklistproject\n#-------------------------------------[INFO]---------------------------------------\n#\n# Summed list\n#------------------------------------[FILTERS]-------------------------------------\n"
+def read_files(files: Generator[str, None, None]) -> str:
+    for f in files:
+        # Skip output file
+        if f != OUTPUT_FILE:
+            for line in open(f, 'r'):
+                # Skip comments
+                if line[0] != '#':
+                    yield line
+
+
+def get_header(line_count: int) -> str:
+    # Info text to go on top, format at "Total number of network filters"
+    return ('#------------------------------------[UPDATE]--------------------------------------\n'
+            '# Title: The Block List Project\n'
+            '# Expires: 1 day\n'
+            '# Homepage: https://blocklist.site\n'
+            '# Help: https://github.com/blocklistproject/lists/wiki/\n'
+            '# License: https://unlicense.org\n'
+            f'# Total number of network filters: {line_count}\n'
+            '#------------------------------------[SUPPORT]-------------------------------------\n'
+            '# You can support by:\n'
+            '# - reporting false positives\n'
+            '# - making a donation: https://paypal.me/blocklistproject\n'
+            '#-------------------------------------[INFO]---------------------------------------\n'
+            '#\n'
+            '# Summed list\n'
+            '#------------------------------------[FILTERS]-------------------------------------\n')
+
+
+# Get every .txt file in folder
+txt_files = (f for f in glob.glob('*.txt'))
 
 # Read all .txt-files and save non-duplicate lines
-for input_file in txt_files:
-    for line in open(input_file, "r"):
-        read_lines.add(line)
+lines_set = set(read_files(txt_files))
 
-# Count, format and sum text
-no_of_lines = len(read_lines)
-info_text = info_text.format(no_of_lines - 16)
-summed_lines = "".join(read_lines)
-
-with open("everything.txt", "w") as output_file:
-    output_file.write(info_text)
-    output_file.write(summed_lines)
+with open(OUTPUT_FILE, "w") as output_file:
+    output_file.write(get_header(len(lines_set)))
+    output_file.write(''.join(lines_set))


### PR DESCRIPTION
I found this repo while looking for new blocklists for my pihole. This commit does change the functionality of the script a bit. Before, the output file would contain all the comments from the txt files. This would cause the "Total number of network filters" line to be incorrect. I now filter out all comments and empty lines from the txt files. I also removed the current working directory line. You can just run the python script in the Lists folder no problem. Also python2 is deprecated since beginning of the year so I only tested Python3 support.